### PR TITLE
Align threads with their spines

### DIFF
--- a/index.css
+++ b/index.css
@@ -234,6 +234,15 @@ div[href="/channels/@me"]:not(:hover) > div {
     background: var(--background-floating);
     border-radius: var(--context-menu-radius);
 }
+/* Align threads with their spines */
+[id*="message-accessories-"]::after {
+    content: "";
+    width: 100%;
+    order: 1;
+}
+.container-3i3IzO {
+    order: 2;
+}
 
 .theme-dark .option-2KkUJO:after {
     background: none;


### PR DESCRIPTION
Threads would previously fall in line along with all the other message accessories, with the spine no longer pointing at it. This forces a break between the thread and the other accessories, fixing that issue.

Before:
![image](https://user-images.githubusercontent.com/32040424/150718325-df53bb51-b406-43c7-b389-fff54b4fdebe.png)

After:
![image](https://user-images.githubusercontent.com/32040424/150718375-15801b9a-fcdb-4244-a500-d4c48e80172a.png)
