### PR TITLE
fix message attachments being listed vertically

### DIFF
--- a/index.css
+++ b/index.css
@@ -230,6 +230,9 @@ div[href="/channels/@me"]:not(:hover) > div {
 [id*="message-reactions"] {
     width: 100%;
 }
+.messageAttachment-CZp8Iv {
+    width: unset;
+}
 .theme-dark .container-2McqkF{
     background: var(--background-floating);
     border-radius: var(--context-menu-radius);


### PR DESCRIPTION
A recent discord update appears to have set the width of all attachments to 100%. This reverts that change.